### PR TITLE
FixMergeContactsIssue

### DIFF
--- a/FreshdeskApi.Client/Contacts/Models/MergeContactFields.cs
+++ b/FreshdeskApi.Client/Contacts/Models/MergeContactFields.cs
@@ -1,0 +1,63 @@
+﻿using Newtonsoft.Json;
+
+namespace FreshdeskApi.Client.Contacts.Models
+{
+    /// <summary>
+    /// The fields for a contact that can be updated during a merge.
+    /// Phone / Mobile / Twitter id / Unique External values are mandatory 
+    /// if they are present in both primary and secondary contacts.
+    ///
+    /// c.f. https://developers.freshdesk.com/api/#merge_contact
+    /// </summary>
+    public class MergeContactFields
+    {
+        /// <summary>
+        /// Primary email address of the contact. If you want to associate
+        /// additional email(s) with this contact, use the other_emails
+        /// attribute
+        /// </summary>
+        [JsonProperty("email")]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// Telephone number of the contact
+        /// </summary>
+        [JsonProperty("phone")]
+        public string? Phone { get; set; }
+
+        /// <summary>
+        /// Mobile number of the contact
+        /// </summary>
+        [JsonProperty("mobile")]
+        public string? Mobile { get; set; }
+
+        /// <summary>
+        /// Twitter handle of the contact
+        /// </summary>
+        [JsonProperty("twitter_id")]
+        public string? TwitterId { get; set; }
+
+        /// <summary>
+        /// External ID of the contact
+        /// </summary>
+        [JsonProperty("unique_external_id")]
+        public string? UniqueExternalId { get; set; }
+
+        /// <summary>
+        /// Additional emails associated with the contact
+        /// </summary>
+        [JsonProperty("other_emails")]
+        public string[]? OtherEmails { get; set; }
+
+        /// <summary>
+        /// IDs of the companies associated with the contact
+        /// </summary>
+        [JsonProperty("company_ids")]
+        public int[]? CompanyIds { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Email)}: {Email}, {nameof(Phone)}: {Phone}, {nameof(Mobile)}: {Mobile}, {nameof(TwitterId)}: {TwitterId}, {nameof(UniqueExternalId)}: {UniqueExternalId}, {nameof(OtherEmails)}: {OtherEmails}, {nameof(CompanyIds)}: {CompanyIds}";
+        }
+    }
+}

--- a/FreshdeskApi.Client/Contacts/Requests/MergeContactsRequest.cs
+++ b/FreshdeskApi.Client/Contacts/Requests/MergeContactsRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using FreshdeskApi.Client.Contacts.Models;
 using Newtonsoft.Json;
 
 namespace FreshdeskApi.Client.Contacts.Requests
@@ -17,10 +18,18 @@ namespace FreshdeskApi.Client.Contacts.Requests
         [JsonProperty("secondary_contact_ids")]
         public List<long> SecondaryContactIds { get; }
 
-        public MergeContactsRequest(long primaryContactId, List<long> secondaryContactIds)
+        /// <summary>
+        /// Contact infromation that can be updated in a merge. Phone, Mobile, Twitter Id and 
+        /// Unique external values are mandatory if they are present in both primary and secondary contacts.
+        /// </summary>
+        [JsonProperty("contact")]
+        public MergeContactFields? Contact { get; }
+
+        public MergeContactsRequest(long primaryContactId, List<long> secondaryContactIds, MergeContactFields? contact = null)
         {
             PrimaryContactId = primaryContactId;
             SecondaryContactIds = secondaryContactIds;
+            Contact = contact;
         }
     }
 }


### PR DESCRIPTION
When merging contacts, if a contact has Phone / Mobile / Twitter id / Unique External values in both contacts that you are merging, they will not merge unless you specify the fields that overlap (https://developers.freshdesk.com/api/#merge_contact). This pull request handles adding the fields in if they are needed.