### PR TITLE
Implement disposing of requests and responses

### DIFF
--- a/FreshdeskApi.Client/Exceptions/FreshdeskApiException.cs
+++ b/FreshdeskApi.Client/Exceptions/FreshdeskApiException.cs
@@ -10,7 +10,7 @@ namespace FreshdeskApi.Client.Exceptions
     /// Will always contain <see cref="HttpResponseMessage"/> with the
     /// request/response details.
     /// </summary>
-    public abstract class FreshdeskApiException : Exception
+    public abstract class FreshdeskApiException : Exception, IDisposable
     {
         /// <summary>
         /// The HTTP response which Freshdesk returned, will often contain
@@ -21,6 +21,11 @@ namespace FreshdeskApi.Client.Exceptions
         internal FreshdeskApiException(HttpResponseMessage response)
         {
             Response = response;
+        }
+
+        public void Dispose()
+        {
+            Response.Dispose();
         }
     }
 }

--- a/FreshdeskApi.Client/FreshdeskClient.cs
+++ b/FreshdeskApi.Client/FreshdeskClient.cs
@@ -179,7 +179,7 @@ namespace FreshdeskApi.Client
             {
                 url += $"&per_page={pagingConfiguration.PageSize}";
             }
-            
+
             using var disposingCollection = new DisposingCollection();
 
             var morePages = true;
@@ -189,7 +189,7 @@ namespace FreshdeskApi.Client
                 var response = await _httpClient
                     .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                     .ConfigureAwait(false);
-                
+
                 SetRateLimitValues(response);
 
                 // Handle rate limiting by waiting the specified amount of time
@@ -201,11 +201,11 @@ namespace FreshdeskApi.Client
                         disposingCollection.Add(response);
 
                         await Task.Delay(response.Headers.RetryAfter.Delta.Value, cancellationToken);
-                        
+
                         response = await _httpClient
                             .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                             .ConfigureAwait(false);
-                        
+
                         SetRateLimitValues(response);
                     }
                     else
@@ -221,7 +221,7 @@ namespace FreshdeskApi.Client
                 {
                     throw CreateApiException(response);
                 }
-                
+
                 // response will not be used outside of this method (i.e. in Exception)
                 disposingCollection.Add(response);
 
@@ -330,7 +330,7 @@ namespace FreshdeskApi.Client
             where TBody : class
         {
             using var disposingCollection = new DisposingCollection();
-            
+
             var response = await ExecuteRequestAsync(method, url, body, cancellationToken);
 
             // Handle rate limiting by waiting the specified amount of time

--- a/FreshdeskApi.Client/FreshdeskClient.cs
+++ b/FreshdeskApi.Client/FreshdeskClient.cs
@@ -283,6 +283,9 @@ namespace FreshdeskApi.Client
                 {
                     morePages = false;
                 }
+
+                // it is safe to call it repeatably
+                disposingCollection.Dispose();
             }
         }
 

--- a/FreshdeskApi.Client/Infrastructure/DisposingCollection.cs
+++ b/FreshdeskApi.Client/Infrastructure/DisposingCollection.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FreshdeskApi.Client.Infrastructure
+{
+    internal sealed class DisposingCollection : IDisposable
+    {
+        private readonly ICollection<IDisposable> _disposables = new List<IDisposable>();
+
+        public void Add(IDisposable disposable)
+        {
+            lock (_disposables)
+            {
+                _disposables.Add(disposable);
+            }
+        }
+
+        public void Dispose()
+        {
+            ICollection<IDisposable> disposables;
+            lock (_disposables)
+            {
+                disposables = _disposables.ToList();
+                _disposables.Clear();
+            }
+
+            foreach (var disposable in disposables)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I did quite a big mistake when I reimplemented `GetPagedResults` and `ApiOperationAsync`. It lacks disposing of `HttpRequestMessage` and `HttpResponseMessage`, which can cause huge memory issues...