### PR TITLE
Adds support for roles.

### DIFF
--- a/FreshdeskApi.Client/Extensions/IocExtensions.cs
+++ b/FreshdeskApi.Client/Extensions/IocExtensions.cs
@@ -9,6 +9,7 @@ using FreshdeskApi.Client.Contacts;
 using FreshdeskApi.Client.Conversations;
 using FreshdeskApi.Client.Groups;
 using FreshdeskApi.Client.Products;
+using FreshdeskApi.Client.Roles;
 using FreshdeskApi.Client.Solutions;
 using FreshdeskApi.Client.TicketFields;
 using FreshdeskApi.Client.Tickets;
@@ -43,6 +44,7 @@ namespace FreshdeskApi.Client.Extensions
             serviceCollection.AddScoped<IFreshdeskTicketClient, FreshdeskTicketClient>();
             serviceCollection.AddScoped<IFreshdeskContactClient, FreshdeskContactClient>();
             serviceCollection.AddScoped<IFreshdeskGroupClient, FreshdeskGroupClient>();
+            serviceCollection.AddScoped<IFreshdeskRoleClient, FreshdeskRoleClient>();
             serviceCollection.AddScoped<IFreshdeskProductClient, FreshdeskProductClient>();
             serviceCollection.AddScoped<IFreshdeskAgentClient, FreshdeskAgentClient>();
             serviceCollection.AddScoped<IFreshdeskCompaniesClient, FreshdeskCompaniesClient>();

--- a/FreshdeskApi.Client/FreshdeskClient.cs
+++ b/FreshdeskApi.Client/FreshdeskClient.cs
@@ -6,6 +6,7 @@ using FreshdeskApi.Client.Contacts;
 using FreshdeskApi.Client.Conversations;
 using FreshdeskApi.Client.Groups;
 using FreshdeskApi.Client.Products;
+using FreshdeskApi.Client.Roles;
 using FreshdeskApi.Client.Solutions;
 using FreshdeskApi.Client.TicketFields;
 using FreshdeskApi.Client.Tickets;
@@ -22,6 +23,8 @@ namespace FreshdeskApi.Client
         public IFreshdeskContactClient Contacts { get; }
 
         public IFreshdeskGroupClient Groups { get; }
+
+        public IFreshdeskRoleClient Roles { get; }
 
         public IFreshdeskProductClient Products { get; }
 
@@ -44,6 +47,7 @@ namespace FreshdeskApi.Client
             IFreshdeskTicketClient freshdeskTicketClient,
             IFreshdeskContactClient freshdeskContactClient,
             IFreshdeskGroupClient freshdeskGroupClient,
+            IFreshdeskRoleClient freshdeskRoleClient,
             IFreshdeskProductClient freshdeskProductClient,
             IFreshdeskAgentClient freshdeskAgentClient,
             IFreshdeskCompaniesClient freshdeskCompaniesClient,
@@ -56,6 +60,7 @@ namespace FreshdeskApi.Client
             Tickets = freshdeskTicketClient;
             Contacts = freshdeskContactClient;
             Groups = freshdeskGroupClient;
+            Roles = freshdeskRoleClient;
             Products = freshdeskProductClient;
             Agents = freshdeskAgentClient;
             Companies = freshdeskCompaniesClient;
@@ -81,6 +86,7 @@ namespace FreshdeskApi.Client
             new FreshdeskTicketClient(httpClient),
             new FreshdeskContactClient(httpClient),
             new FreshdeskGroupClient(httpClient),
+            new FreshdeskRoleClient(httpClient),
             new FreshdeskProductClient(httpClient),
             new FreshdeskAgentClient(httpClient),
             new FreshdeskCompaniesClient(httpClient),

--- a/FreshdeskApi.Client/Roles/FreshdeskRoleClient.cs
+++ b/FreshdeskApi.Client/Roles/FreshdeskRoleClient.cs
@@ -1,10 +1,10 @@
-using FreshdeskApi.Client.Roles.Models;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using FreshdeskApi.Client.Roles.Models;
 
 namespace FreshdeskApi.Client.Roles
 {

--- a/FreshdeskApi.Client/Roles/FreshdeskRoleClient.cs
+++ b/FreshdeskApi.Client/Roles/FreshdeskRoleClient.cs
@@ -1,0 +1,45 @@
+using FreshdeskApi.Client.Roles.Models;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FreshdeskApi.Client.Roles
+{
+    /// <inheritdoc />
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public class FreshdeskRoleClient : IFreshdeskRoleClient
+    {
+        private readonly IFreshdeskHttpClient _freshdeskClient;
+
+        public FreshdeskRoleClient(IFreshdeskHttpClient freshdeskClient)
+        {
+            _freshdeskClient = freshdeskClient;
+        }
+
+        /// <inheritdoc />
+        public async Task<Role> ViewRoleAsync(
+            long roleId,
+            CancellationToken cancellationToken = default)
+        {
+            return await _freshdeskClient
+                .ApiOperationAsync<Role>(HttpMethod.Get, $"/api/v2/roles/{roleId}", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async IAsyncEnumerable<Role> ListAllRolesAsync(
+            IPaginationConfiguration? pagingConfiguration = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await foreach (var role in _freshdeskClient
+                .GetPagedResults<Role>("/api/v2/roles", pagingConfiguration, false, cancellationToken)
+                .ConfigureAwait(false))
+            {
+                yield return role;
+            }
+        }
+    }
+}

--- a/FreshdeskApi.Client/Roles/IFreshdeskRoleClient.cs
+++ b/FreshdeskApi.Client/Roles/IFreshdeskRoleClient.cs
@@ -1,7 +1,7 @@
-using FreshdeskApi.Client.Roles.Models;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using FreshdeskApi.Client.Roles.Models;
 
 namespace FreshdeskApi.Client.Roles
 {

--- a/FreshdeskApi.Client/Roles/IFreshdeskRoleClient.cs
+++ b/FreshdeskApi.Client/Roles/IFreshdeskRoleClient.cs
@@ -1,0 +1,43 @@
+using FreshdeskApi.Client.Roles.Models;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FreshdeskApi.Client.Roles
+{
+    public interface IFreshdeskRoleClient
+    {
+        /// <summary>
+        /// Retrieve all details about a single role by its id.
+        ///
+        /// c.f. https://developers.freshdesk.com/api/#view_role
+        /// </summary>
+        /// <param name="roleId">
+        /// The unique identifier for the role.
+        /// </param>
+        ///
+        /// <param name="cancellationToken"></param>
+        ///
+        /// <returns>The full role information</returns>
+        Task<Role> ViewRoleAsync(
+            long roleId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all available roles
+        ///
+        /// c.f. https://developers.freshdesk.com/api/#list_all_roles
+        /// </summary>
+        ///
+        /// <param name="pagingConfiguration"></param>
+        /// <param name="cancellationToken"></param>
+        ///
+        /// <returns>
+        /// The full set of roles, this request is paged and iterating to the
+        /// next entry may cause a new API call to get the next page.
+        /// </returns>
+        IAsyncEnumerable<Role> ListAllRolesAsync(
+            IPaginationConfiguration? pagingConfiguration = null,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/FreshdeskApi.Client/Roles/Models/Role.cs
+++ b/FreshdeskApi.Client/Roles/Models/Role.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace FreshdeskApi.Client.Roles.Models
+{
+    /// <summary>
+    /// Refers to a role of agents (as specified in the
+    /// <see cref="Id"/> parameter).
+    ///
+    /// c.f. https://developers.freshdesk.com/api/#view_role
+    /// </summary>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public class Role
+    {
+        /// <summary>
+        /// Unique ID of the role
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Name of the role
+        /// </summary>
+        [JsonProperty("name")]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Description of the role
+        /// </summary>
+        [JsonProperty("description")]
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// True if this is the default role
+        /// </summary>
+        [JsonProperty("default")]
+        public bool Default { get; set; }
+
+        /// Role creation timestamp
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        /// <summary>
+        /// Role updated timestamp
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Id)}: {Id}, {nameof(Name)}: {Name}, {nameof(Description)}: {Description}, {nameof(Default)}: {Default}, {nameof(CreatedAt)}: {CreatedAt}, {nameof(UpdatedAt)}: {UpdatedAt}";
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Conversations|:heavy_check_mark:
 Contacts|:heavy_check_mark:
 Agents|:heavy_check_mark:
 Skills|:x:
-Roles|:x:
+Roles|:heavy_check_mark:
 Groups|:heavy_check_mark:
 Companies|:heavy_check_mark:
 Canned Response Folders|:x:


### PR DESCRIPTION
This adds support for getting information about roles:

https://developers.freshdesk.com/api/#roles

Roles are read only via the API. Otherwise, this is consistent with everything else.

This has been tested against Freshdesk.