### PR TITLE
Adds support for getting information about me.

### DIFF
--- a/FreshdeskApi.Client/Extensions/IocExtensions.cs
+++ b/FreshdeskApi.Client/Extensions/IocExtensions.cs
@@ -8,6 +8,7 @@ using FreshdeskApi.Client.Companies;
 using FreshdeskApi.Client.Contacts;
 using FreshdeskApi.Client.Conversations;
 using FreshdeskApi.Client.Groups;
+using FreshdeskApi.Client.Me;
 using FreshdeskApi.Client.Products;
 using FreshdeskApi.Client.Solutions;
 using FreshdeskApi.Client.TicketFields;
@@ -44,6 +45,7 @@ namespace FreshdeskApi.Client.Extensions
             serviceCollection.AddScoped<IFreshdeskContactClient, FreshdeskContactClient>();
             serviceCollection.AddScoped<IFreshdeskGroupClient, FreshdeskGroupClient>();
             serviceCollection.AddScoped<IFreshdeskProductClient, FreshdeskProductClient>();
+            serviceCollection.AddScoped<IFreshdeskMeClient, FreshdeskMeClient>();
             serviceCollection.AddScoped<IFreshdeskAgentClient, FreshdeskAgentClient>();
             serviceCollection.AddScoped<IFreshdeskCompaniesClient, FreshdeskCompaniesClient>();
             serviceCollection.AddScoped<IFreshdeskSolutionClient, FreshdeskSolutionClient>();

--- a/FreshdeskApi.Client/FreshdeskClient.cs
+++ b/FreshdeskApi.Client/FreshdeskClient.cs
@@ -5,6 +5,7 @@ using FreshdeskApi.Client.Companies;
 using FreshdeskApi.Client.Contacts;
 using FreshdeskApi.Client.Conversations;
 using FreshdeskApi.Client.Groups;
+using FreshdeskApi.Client.Me;
 using FreshdeskApi.Client.Products;
 using FreshdeskApi.Client.Solutions;
 using FreshdeskApi.Client.TicketFields;
@@ -25,6 +26,8 @@ namespace FreshdeskApi.Client
 
         public IFreshdeskProductClient Products { get; }
 
+        public IFreshdeskMeClient Me { get; }
+        
         public IFreshdeskAgentClient Agents { get; }
 
         public IFreshdeskCompaniesClient Companies { get; }
@@ -45,6 +48,7 @@ namespace FreshdeskApi.Client
             IFreshdeskContactClient freshdeskContactClient,
             IFreshdeskGroupClient freshdeskGroupClient,
             IFreshdeskProductClient freshdeskProductClient,
+            IFreshdeskMeClient freshdeskMeClient,
             IFreshdeskAgentClient freshdeskAgentClient,
             IFreshdeskCompaniesClient freshdeskCompaniesClient,
             IFreshdeskSolutionClient freshdeskSolutionClient,
@@ -57,6 +61,7 @@ namespace FreshdeskApi.Client
             Contacts = freshdeskContactClient;
             Groups = freshdeskGroupClient;
             Products = freshdeskProductClient;
+            Me = freshdeskMeClient;
             Agents = freshdeskAgentClient;
             Companies = freshdeskCompaniesClient;
             Solutions = freshdeskSolutionClient;
@@ -82,6 +87,7 @@ namespace FreshdeskApi.Client
             new FreshdeskContactClient(httpClient),
             new FreshdeskGroupClient(httpClient),
             new FreshdeskProductClient(httpClient),
+            new FreshdeskMeClient(httpClient),
             new FreshdeskAgentClient(httpClient),
             new FreshdeskCompaniesClient(httpClient),
             new FreshdeskSolutionClient(httpClient),

--- a/FreshdeskApi.Client/FreshdeskClient.cs
+++ b/FreshdeskApi.Client/FreshdeskClient.cs
@@ -27,7 +27,7 @@ namespace FreshdeskApi.Client
         public IFreshdeskProductClient Products { get; }
 
         public IFreshdeskMeClient Me { get; }
-        
+
         public IFreshdeskAgentClient Agents { get; }
 
         public IFreshdeskCompaniesClient Companies { get; }

--- a/FreshdeskApi.Client/Me/FreshdeskMeClient.cs
+++ b/FreshdeskApi.Client/Me/FreshdeskMeClient.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FreshdeskApi.Client.Me
+{
+    /// <inheritdoc />
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public class FreshdeskMeClient : IFreshdeskMeClient
+    {
+        private readonly IFreshdeskHttpClient _freshdeskClient;
+
+        public FreshdeskMeClient(IFreshdeskHttpClient freshdeskClient)
+        {
+            _freshdeskClient = freshdeskClient;
+        }
+
+        /// <inheritdoc />
+        public async Task<Models.Me> ViewMeAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return await _freshdeskClient
+                .ApiOperationAsync<Models.Me>(HttpMethod.Get, $"/api/v2/agents/me", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/FreshdeskApi.Client/Me/IFreshdeskMeClient.cs
+++ b/FreshdeskApi.Client/Me/IFreshdeskMeClient.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FreshdeskApi.Client.Me
+{
+    public interface IFreshdeskMeClient
+    {
+        /// <summary>
+        /// Retrieve all details about a current agent, identified by the API-key.
+        ///
+        /// c.f. https://developers.freshdesk.com/api/#me
+        /// </summary>
+        ///
+        /// <param name="cancellationToken"></param>
+        ///
+        /// <returns>The full agent information</returns>
+        Task<Models.Me> ViewMeAsync(
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/FreshdeskApi.Client/Me/Models/Me.cs
+++ b/FreshdeskApi.Client/Me/Models/Me.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using FreshdeskApi.Client.Agents.Models;
+using FreshdeskApi.Client.Contacts.Models;
+using Newtonsoft.Json;
+
+namespace FreshdeskApi.Client.Me.Models
+{
+    /// <summary>
+    /// Refers to an agent as seen on Freshdesk API
+    ///
+    /// c.f. https://developers.freshdesk.com/api/#agents
+    /// </summary>
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public class Me
+    {
+        /// <summary>
+        /// If the agent is in a group that has enabled "Automatic Ticket
+        /// Assignment", this attribute will be set to true if the agent
+        /// is accepting new tickets
+        /// </summary>
+        [JsonProperty("available")]
+        public bool Available { get; set; }
+
+        /// <summary>
+        /// Set to true if this is an occasional agent (true => occasional,
+        /// false => full-time)
+        /// </summary>
+        [JsonProperty("occasional")]
+        public bool Occasional { get; set; }
+
+        /// <summary>
+        /// User ID of the agent
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Ticket permission of the agent
+        /// </summary>
+        [JsonProperty("ticket_scope")]
+        public TicketScope TicketScope { get; set; }
+
+        /// <summary>
+        /// Signature of the agent in HTML format
+        /// </summary>
+        [JsonProperty("signature")]
+        public string? Signature { get; set; }
+
+        /// <summary>
+        /// Group IDs associated with the agent
+        /// </summary>
+        [JsonProperty("group_ids")]
+        public long[]? GroupIds { get; set; }
+
+        /// <summary>
+        /// Role IDs associated with the agent
+        /// </summary>
+        [JsonProperty("role_ids")]
+        public long[]? RoleIds { get; set; }
+
+        /// <summary>
+        /// Skill ids associated with the agent
+        /// </summary>
+        [JsonProperty("skill_ids")]
+        public long[]? SkillIds { get; set; }
+
+        /// <summary>
+        /// Agent creation timestamp
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        /// <summary>
+        /// Agent updated timestamp
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; }
+
+        /// <summary>
+        /// Timestamp that denotes when the agent became available/unavailable
+        /// (depending on the value of the 'available' attribute)
+        /// </summary>
+        [JsonProperty("available_since")]
+        public DateTimeOffset? AvailableSince { get; set; }
+
+        [JsonProperty("type")]
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// All agents are also contacts, this is the full set of contact
+        /// information about the agent.
+        /// </summary>
+        [JsonProperty("contact")]
+        public Contact? Contact { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Available)}: {Available}, {nameof(Occasional)}: {Occasional}, {nameof(Id)}: {Id}, {nameof(TicketScope)}: {TicketScope}, {nameof(Signature)}: {Signature}, {nameof(GroupIds)}: {GroupIds}, {nameof(RoleIds)}: {RoleIds}, {nameof(SkillIds)}: {SkillIds}, {nameof(CreatedAt)}: {CreatedAt}, {nameof(UpdatedAt)}: {UpdatedAt}, {nameof(AvailableSince)}: {AvailableSince}, {nameof(Type)}: {Type}, {nameof(Contact)}: {Contact}";
+        }
+    }
+}


### PR DESCRIPTION
This adds support for getting information about the current agent (that is using the API): 

https://developers.freshdesk.com/api/#me

I made it so you could call:

    var me = await freshdeskClient.Me.ViewMeAsync();

This is discussable :-) This function could also have been added in the Agents-property, I think. But I have seen other SDK:s having a “Me” property, like the one for MS Graph.

This has been tested against Freshdesk.
