### PR TITLE
The ContactBase.TwitterProfileStatus may be null

### DIFF
--- a/FreshdeskApi.Client/Contacts/Models/ContactBase.cs
+++ b/FreshdeskApi.Client/Contacts/Models/ContactBase.cs
@@ -144,7 +144,7 @@ namespace FreshdeskApi.Client.Contacts.Models
         public string? UniqueExternalId { get; set; }
 
         [JsonProperty("twitter_profile_status")]
-        public bool TwitterProfileStatus { get; set; }
+        public bool? TwitterProfileStatus { get; set; }
 
         [JsonProperty("twitter_followers_count")]
         public long? TwitterFollowersCount { get; set; }


### PR DESCRIPTION
We catch following error on our server:

`Newtonsoft.Json.JsonSerializationException`: Error converting value {null} to type 'System.Boolean'. Path '[6].twitter_profile_status'
`System.InvalidCastException`: Null object cannot be converted to a value type.

This PR should resolve it
