### PR TITLE
Add Description option to TicketIncludes

### DIFF
--- a/FreshdeskApi.Client/Tickets/Models/TicketIncludes.cs
+++ b/FreshdeskApi.Client/Tickets/Models/TicketIncludes.cs
@@ -38,7 +38,7 @@ namespace FreshdeskApi.Client.Tickets.Models
         /// Causes description and descriptiontext fields to be included when listing tickets.
         /// </summary>
         public bool Description;
-        
+
         public override string ToString()
         {
             var sb = new StringBuilder();
@@ -48,7 +48,7 @@ namespace FreshdeskApi.Client.Tickets.Models
             if (Requester) sb.Append(",requester");
             if (Stats) sb.Append(",stats");
             if (Description) sb.Append(",description");
-            
+
             return sb.ToString().TrimStart(',');
         }
     }

--- a/FreshdeskApi.Client/Tickets/Models/TicketIncludes.cs
+++ b/FreshdeskApi.Client/Tickets/Models/TicketIncludes.cs
@@ -34,6 +34,11 @@ namespace FreshdeskApi.Client.Tickets.Models
         /// </summary>
         public bool Stats;
 
+        /// <summary>
+        /// Causes description and descriptiontext fields to be included when listing tickets.
+        /// </summary>
+        public bool Description;
+        
         public override string ToString()
         {
             var sb = new StringBuilder();
@@ -42,7 +47,8 @@ namespace FreshdeskApi.Client.Tickets.Models
             if (Conversations) sb.Append(",conversations");
             if (Requester) sb.Append(",requester");
             if (Stats) sb.Append(",stats");
-
+            if (Description) sb.Append(",description");
+            
             return sb.ToString().TrimStart(',');
         }
     }


### PR DESCRIPTION
Per the v2 documentation "For accounts created after 2018-11-30, you will have to use include to get description" on List All Tickets requests