### PR TITLE
Fix deserialization of Ticket when `due_by` is null

### DIFF
--- a/FreshdeskApi.Client.UnitTests/Tickets/Models/TicketTests.cs
+++ b/FreshdeskApi.Client.UnitTests/Tickets/Models/TicketTests.cs
@@ -1,0 +1,77 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace FreshdeskApi.Client.UnitTests.Tickets.Models;
+
+public sealed class TicketTests
+{
+    [Fact]
+    public void DeserializeTicketTest()
+    {
+        var stream = new MemoryStream();
+
+        using (var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(ExampleTicketJson);
+        }
+
+        stream.Position = 0;
+
+        using var reader = new StreamReader(stream);
+        using var jsonReader = new JsonTextReader(reader);
+        var serializer = new JsonSerializer();
+
+        // Act
+        var ticket = serializer.Deserialize<FreshdeskApi.Client.Tickets.Models.Ticket>(jsonReader);
+
+        // Assert
+        Assert.NotNull(ticket);
+        Assert.Equal("This is a test ticket.", ticket.DescriptionText);
+    }
+
+    [StringSyntax(StringSyntaxAttribute.Json)]
+    private const string ExampleTicketJson =
+        """
+        {
+            "cc_emails": [],
+            "fwd_emails": [],
+            "reply_cc_emails": [],
+            "ticket_cc_emails": [],
+            "ticket_bcc_emails": [],
+            "fr_escalated": false,
+            "spam": false,
+            "email_config_id": null,
+            "group_id": null,
+            "priority": 2,
+            "requester_id": 36012621950,
+            "responder_id": null,
+            "source": 2,
+            "company_id": null,
+            "status": 2,
+            "subject": "A test ticket",
+            "support_email": null,
+            "to_emails": null,
+            "product_id": null,
+            "id": 49548,
+            "type": "Question",
+            "due_by": null,
+            "fr_due_by": null,
+            "is_escalated": false,
+            "description": "<div>This is a test ticket.</div>",
+            "description_text": "This is a test ticket.",
+            "custom_fields": {},
+            "created_at": "2025-01-08T09:43:49Z",
+            "updated_at": "2025-01-08T09:43:50Z",
+            "tags": [
+                "test-tag"
+            ],
+            "attachments": [],
+            "form_id": 298,
+            "nr_due_by": null,
+            "nr_escalated": false
+        }
+        """;
+}

--- a/FreshdeskApi.Client/Tickets/Models/Ticket.cs
+++ b/FreshdeskApi.Client/Tickets/Models/Ticket.cs
@@ -79,10 +79,10 @@ public class Ticket
     public string? Type { get; set; }
 
     [JsonProperty("due_by")]
-    public DateTimeOffset DueBy { get; set; }
+    public DateTimeOffset? DueBy { get; set; }
 
     [JsonProperty("fr_due_by")]
-    public DateTimeOffset FirstResponseDueBy { get; set; }
+    public DateTimeOffset? FirstResponseDueBy { get; set; }
 
     [JsonProperty("is_escalated")]
     public bool IsEscalated { get; set; }


### PR DESCRIPTION
We were seeing errors on `CreateTicketAsync`, where deserialization to `Ticket` was failing. This PR adds a test using the JSON from a response, and fixes the nullability annotations  on the type.

```
Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.DateTimeOffset'. Path 'due_by', line 23, position 18.
```

```
Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.DateTimeOffset'. Path 'fr_due_by', line 24, position 21.
```