### PR TITLE
Fix FilterTicketsAsync not working, should close #230

### DIFF
--- a/FreshdeskApi.Client/Tickets/FreshdeskTicketClient.cs
+++ b/FreshdeskApi.Client/Tickets/FreshdeskTicketClient.cs
@@ -120,7 +120,7 @@ public class FreshdeskTicketClient : IFreshdeskTicketClient
         pagingConfiguration ??= new PageBasedPaginationConfiguration();
 
         await foreach (var ticket in _freshdeskClient
-            .GetPagedResults<Ticket>($"/api/v2/search/tickets?query={encodedQuery}", pagingConfiguration, cancellationToken)
+            .GetPagedResults<Ticket>($"/api/v2/search/tickets?query=\"{encodedQuery}\"", pagingConfiguration, cancellationToken)
             .ConfigureAwait(false))
         {
             yield return ticket;


### PR DESCRIPTION
This is working now with the change:
var tickets = freshdeskClient.Tickets.FilterTicketsAsync("status:2");

See https://developers.freshdesk.com/api/#filter_tickets
4. Query string must be enclosed between a pair of double quotes.

Example
https://domain.freshdesk.com/api/v2/search/tickets?query="priority:3"