### PR TITLE
Bump ReportGenerator from 5.5.4 to 5.5.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.4" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.5" />
   </ItemGroup>
 
   <!-- Framework-specific packages for netstandard2.1 -->

--- a/FreshdeskApi.Client.UnitTests/packages.lock.json
+++ b/FreshdeskApi.Client.UnitTests/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.4, )",
-        "resolved": "5.5.4",
-        "contentHash": "URgEzVsXQHwG1XYq0ltK4Bp5WMIqKq+aPk/bMgEwGtltEaAfcfrVT5SBjbDeZiLsRMwEggj1GQMf8OYyeVWfRA=="
+        "requested": "[5.5.5, )",
+        "resolved": "5.5.5",
+        "contentHash": "cgHZ0LyVrwX4Li2rAdaEGZG+6rvMW3l7T6pUhCcTXhC6nf7Z5EihacAaWePPYshgZIjrWA4E0Ii7Z4eFTwjl3A=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -344,9 +344,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.4, )",
-        "resolved": "5.5.4",
-        "contentHash": "URgEzVsXQHwG1XYq0ltK4Bp5WMIqKq+aPk/bMgEwGtltEaAfcfrVT5SBjbDeZiLsRMwEggj1GQMf8OYyeVWfRA=="
+        "requested": "[5.5.5, )",
+        "resolved": "5.5.5",
+        "contentHash": "cgHZ0LyVrwX4Li2rAdaEGZG+6rvMW3l7T6pUhCcTXhC6nf7Z5EihacAaWePPYshgZIjrWA4E0Ii7Z4eFTwjl3A=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -662,9 +662,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.4, )",
-        "resolved": "5.5.4",
-        "contentHash": "URgEzVsXQHwG1XYq0ltK4Bp5WMIqKq+aPk/bMgEwGtltEaAfcfrVT5SBjbDeZiLsRMwEggj1GQMf8OYyeVWfRA=="
+        "requested": "[5.5.5, )",
+        "resolved": "5.5.5",
+        "contentHash": "cgHZ0LyVrwX4Li2rAdaEGZG+6rvMW3l7T6pUhCcTXhC6nf7Z5EihacAaWePPYshgZIjrWA4E0Ii7Z4eFTwjl3A=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",


### PR DESCRIPTION
Updates 1 packages:

- Update ReportGenerator from 5.5.4 to 5.5.5
