### PR TITLE
Bump ReportGenerator from 5.5.5 to 5.5.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.5" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.6" />
   </ItemGroup>
 
   <!-- Framework-specific packages for netstandard2.1 -->

--- a/FreshdeskApi.Client.UnitTests/packages.lock.json
+++ b/FreshdeskApi.Client.UnitTests/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.5, )",
-        "resolved": "5.5.5",
-        "contentHash": "cgHZ0LyVrwX4Li2rAdaEGZG+6rvMW3l7T6pUhCcTXhC6nf7Z5EihacAaWePPYshgZIjrWA4E0Ii7Z4eFTwjl3A=="
+        "requested": "[5.5.6, )",
+        "resolved": "5.5.6",
+        "contentHash": "yqMycJZHmGUcYOX3Q/t6e0SmaGBBOg3WnrVfD273uOknJumOdclbPpGgpVBOVWso0Sulw2zeAdXG+KyUCV+W8w=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -344,9 +344,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.5, )",
-        "resolved": "5.5.5",
-        "contentHash": "cgHZ0LyVrwX4Li2rAdaEGZG+6rvMW3l7T6pUhCcTXhC6nf7Z5EihacAaWePPYshgZIjrWA4E0Ii7Z4eFTwjl3A=="
+        "requested": "[5.5.6, )",
+        "resolved": "5.5.6",
+        "contentHash": "yqMycJZHmGUcYOX3Q/t6e0SmaGBBOg3WnrVfD273uOknJumOdclbPpGgpVBOVWso0Sulw2zeAdXG+KyUCV+W8w=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -662,9 +662,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.5, )",
-        "resolved": "5.5.5",
-        "contentHash": "cgHZ0LyVrwX4Li2rAdaEGZG+6rvMW3l7T6pUhCcTXhC6nf7Z5EihacAaWePPYshgZIjrWA4E0Ii7Z4eFTwjl3A=="
+        "requested": "[5.5.6, )",
+        "resolved": "5.5.6",
+        "contentHash": "yqMycJZHmGUcYOX3Q/t6e0SmaGBBOg3WnrVfD273uOknJumOdclbPpGgpVBOVWso0Sulw2zeAdXG+KyUCV+W8w=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",


### PR DESCRIPTION
Updates 1 packages:

- Update ReportGenerator from 5.5.5 to 5.5.6
