### PR TITLE
fix: migrate nightly package deploy from MyGet to Feedz.io

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,4 +1,4 @@
-name: Nightly Feedz Package Deploy
+name: Nightly Package Deploy
 
 on:
   push:
@@ -42,6 +42,9 @@ jobs:
         with:
           name: Nuget-packages-${{ steps.gitversion.outputs.FullSemVer }}
           path: nuget-packages
+      - name: Push package to MyGet
+        if: ${{ vars.USE_MYGET == 'true' }}
+        run: dotnet nuget push 'nuget-packages/*.nupkg' --api-key ${{ secrets.MYGET_API_KEY }} --source https://www.myget.org/F/freshdesk-api-dotnet/api/v3/index.json
       - name: Push package to Feedz
         if: ${{ vars.USE_FEEDZ == 'true' }}
         run: dotnet nuget push 'nuget-packages/*.nupkg' --api-key ${{ secrets.FEEDZ_API_KEY }} --source https://f.feedz.io/aviationexam/freshdesk/nuget/index.json

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,4 +1,4 @@
-name: Nightly MyGet Package Deploy
+name: Nightly Feedz Package Deploy
 
 on:
   push:
@@ -42,5 +42,6 @@ jobs:
         with:
           name: Nuget-packages-${{ steps.gitversion.outputs.FullSemVer }}
           path: nuget-packages
-      - name: Push package to nuget
-        run: dotnet nuget push 'nuget-packages/*.nupkg' --api-key ${{ secrets.MYGET_API_KEY }} --source https://www.myget.org/F/freshdesk-api-dotnet/api/v3/index.json
+      - name: Push package to Feedz
+        if: ${{ vars.USE_FEEDZ == 'true' }}
+        run: dotnet nuget push 'nuget-packages/*.nupkg' --api-key ${{ secrets.FEEDZ_API_KEY }} --source https://f.feedz.io/aviationexam/freshdesk/nuget/index.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://github.com/DaveTCode/FreshdeskApiDotnet/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/DaveTCode/FreshdeskApiDotnet/actions/workflows/build.yml)
 [![NuGet](https://img.shields.io/nuget/v/Freshdesk.Api.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Freshdesk.Api/)
-[![MyGet](https://img.shields.io/myget/freshdesk-api-dotnet/vpre/Freshdesk.Api?label=MyGet)](https://www.myget.org/feed/freshdesk-api-dotnet/package/nuget/Freshdesk.Api)
+[![Feedz](https://img.shields.io/badge/feedz-latest-blue)](https://f.feedz.io/aviationexam/freshdesk/nuget/index.json)
 
 
 # Freshdesk API Client


### PR DESCRIPTION
## Summary

- MyGet has been unstable, causing nightly package deploy failures (see [failed run](https://github.com/DaveTCode/FreshdeskApiDotnet/actions/runs/24725578170/job/72325572112#step:12:70))
- Migrate pre-release NuGet publishing from MyGet to [Feedz.io](https://f.feedz.io/aviationexam/freshdesk/nuget/index.json)
- Pattern taken from [aviationexam/json-converter-source-generator](https://github.com/aviationexam/json-converter-source-generator)

## Changes

- **`.github/workflows/nightly-release.yml`**:
  - Renamed workflow from "Nightly MyGet Package Deploy" → "Nightly Feedz Package Deploy"
  - Replaced `MYGET_API_KEY` secret with `FEEDZ_API_KEY`
  - Replaced MyGet source URL with `https://f.feedz.io/aviationexam/freshdesk/nuget/index.json`
  - Added `vars.USE_FEEDZ == 'true'` conditional gate (consistent with aviationexam repos)
- **`README.md`**: Replaced MyGet badge with Feedz.io badge

## Required Setup (before merging)

1. **Add repository secret** `FEEDZ_API_KEY` with the Feedz.io API key
2. **Add repository variable** `USE_FEEDZ` = `true` to enable publishing
3. Optionally remove the old `MYGET_API_KEY` secret

## Release workflow

The `release.yml` workflow (publishing to nuget.org on GitHub releases) is **unchanged** — it continues to use `NUGET_API_KEY`.