### PR TITLE
Bump ReportGenerator from 5.5.7 to 5.5.9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.2" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.7" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.9" />
   </ItemGroup>
 
   <!-- Framework-specific packages for netstandard2.1 -->

--- a/FreshdeskApi.Client.UnitTests/packages.lock.json
+++ b/FreshdeskApi.Client.UnitTests/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.7, )",
-        "resolved": "5.5.7",
-        "contentHash": "qqSd+2/dLAfJA+3BH/LG3UHe9yLOg/HqhU3JlxCOdbQj/VpJOcC11aAM77bUuZ/Mp5/vuglTA23PocLtBYOesw=="
+        "requested": "[5.5.9, )",
+        "resolved": "5.5.9",
+        "contentHash": "cUon/BKlcqj2C/qFAMd5LxSmxOmbkYlbqCL0zHGCaS9WgwhKnOmY1u8kB3LkIc3+Q+HU6E3xRvZJtvoPhMrHkw=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -344,9 +344,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.7, )",
-        "resolved": "5.5.7",
-        "contentHash": "qqSd+2/dLAfJA+3BH/LG3UHe9yLOg/HqhU3JlxCOdbQj/VpJOcC11aAM77bUuZ/Mp5/vuglTA23PocLtBYOesw=="
+        "requested": "[5.5.9, )",
+        "resolved": "5.5.9",
+        "contentHash": "cUon/BKlcqj2C/qFAMd5LxSmxOmbkYlbqCL0zHGCaS9WgwhKnOmY1u8kB3LkIc3+Q+HU6E3xRvZJtvoPhMrHkw=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -662,9 +662,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.7, )",
-        "resolved": "5.5.7",
-        "contentHash": "qqSd+2/dLAfJA+3BH/LG3UHe9yLOg/HqhU3JlxCOdbQj/VpJOcC11aAM77bUuZ/Mp5/vuglTA23PocLtBYOesw=="
+        "requested": "[5.5.9, )",
+        "resolved": "5.5.9",
+        "contentHash": "cUon/BKlcqj2C/qFAMd5LxSmxOmbkYlbqCL0zHGCaS9WgwhKnOmY1u8kB3LkIc3+Q+HU6E3xRvZJtvoPhMrHkw=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",


### PR DESCRIPTION
Updates 1 packages:

- Update ReportGenerator from 5.5.7 to 5.5.9
