### PR TITLE
Bump ReportGenerator from 5.5.9 to 5.5.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.2" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.9" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.10" />
   </ItemGroup>
 
   <!-- Framework-specific packages for netstandard2.1 -->

--- a/FreshdeskApi.Client.UnitTests/packages.lock.json
+++ b/FreshdeskApi.Client.UnitTests/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.9, )",
-        "resolved": "5.5.9",
-        "contentHash": "cUon/BKlcqj2C/qFAMd5LxSmxOmbkYlbqCL0zHGCaS9WgwhKnOmY1u8kB3LkIc3+Q+HU6E3xRvZJtvoPhMrHkw=="
+        "requested": "[5.5.10, )",
+        "resolved": "5.5.10",
+        "contentHash": "jtYGRv212OcCa6NUmHGEGcB3I8OBSpBjeywrivOWUG/VC1/Wb/v1GNP2Larx6yOUIulQveQ27U1R6nSuUSLXrw=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -344,9 +344,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.9, )",
-        "resolved": "5.5.9",
-        "contentHash": "cUon/BKlcqj2C/qFAMd5LxSmxOmbkYlbqCL0zHGCaS9WgwhKnOmY1u8kB3LkIc3+Q+HU6E3xRvZJtvoPhMrHkw=="
+        "requested": "[5.5.10, )",
+        "resolved": "5.5.10",
+        "contentHash": "jtYGRv212OcCa6NUmHGEGcB3I8OBSpBjeywrivOWUG/VC1/Wb/v1GNP2Larx6yOUIulQveQ27U1R6nSuUSLXrw=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
@@ -662,9 +662,9 @@
       },
       "ReportGenerator": {
         "type": "Direct",
-        "requested": "[5.5.9, )",
-        "resolved": "5.5.9",
-        "contentHash": "cUon/BKlcqj2C/qFAMd5LxSmxOmbkYlbqCL0zHGCaS9WgwhKnOmY1u8kB3LkIc3+Q+HU6E3xRvZJtvoPhMrHkw=="
+        "requested": "[5.5.10, )",
+        "resolved": "5.5.10",
+        "contentHash": "jtYGRv212OcCa6NUmHGEGcB3I8OBSpBjeywrivOWUG/VC1/Wb/v1GNP2Larx6yOUIulQveQ27U1R6nSuUSLXrw=="
       },
       "xunit.v3.mtp-v2": {
         "type": "Direct",


### PR DESCRIPTION
Updates 1 packages:

- Update ReportGenerator from 5.5.9 to 5.5.10
